### PR TITLE
keybindings + more shortcuts + more features brought back from patchetti, tweaks

### DIFF
--- a/FormulaDevice.txt
+++ b/FormulaDevice.txt
@@ -1,0 +1,57 @@
+--[[ Input variables ---------------- ]]--
+A : First input parameter [0..1]
+B : Second input parameter [0..1]
+C : Third input parameter [0..1]
+--
+--[[ Math constants ----------------- ]]--
+PI : Pi constant
+TWOPI : Two Pi constant
+INF : Plus infinity (huge number)
+--
+--[[ Musical variables -------------- ]]--
+SRATE : Actual sampling rate
+BEATS : Current position in beats
+SAMPLES : Current position in samples
+PLAYING : Play or stopped
+BPM : Beats per minute
+LPB : Lines per beat
+TPL : Ticks per line
+SPL : Samples per line
+LINE : Line number in current pattern (integer)
+LINEF : Line number in current pattern (fractional)
+NUMLINES : Number of lines in current pattern
+TICK : Tick number in current line
+TICKCOUNTER : Absolute tick count
+SEQPOS : Current pattern index in sequencer
+--
+--[[ Functions ---------------------- ]]--
+abs(x) : Absolute value
+acos(x) : Arc cosine
+asin(x) : Arc sine
+atan(x) : Arc tangent
+ceil(x) : Round number to ceil
+cos(x) : Cosine
+cosh(x) : Hyperbolic cosine
+deg(x) : Convert to degrees
+exp(x) : Exponential (e^x)
+floor(x) : Round number to floor
+fmod(x) : Modulo operator for float numbers
+frexp(x) : Split value in fraction and exponent
+ldexp(x) : Float representation for a normalised number
+lin2db(x): Convert a 0..1 number to its decibel value
+db2lin(x): Convert a decibel value to its 0..1 normalised value
+log(x) : Natural logarithm of a number
+log10(x) : Logarithm base 10 of a number
+max(a, b [, c[, ...]]) : Maximum of two or more numbers
+min(a, b [, c[, ...]]) : Minimum of two or more numbers
+mod(x) : Modulo operator
+modf(x) : Integral and fractional parts of a number
+pow(x, n): Nth power of x
+rad(x) : Convert to radians
+random([a [, b [, c]]]) : Random value
+randomseed(x): Seed the random number generator
+sin(x) : Sine
+sinh(x) : Hyperbolic sine
+sqrt(x) : Square root
+tan(x) : Tangent
+tanh(x) : Hyperbolic tangent

--- a/FormulaDeviceManual.lua
+++ b/FormulaDeviceManual.lua
@@ -1,0 +1,141 @@
+--[[----------------------------------------------------------------------------
+
+  Author : Alexander Stoica
+  Creation Date : 07/27/2010
+  Last modified : 07/27/2010
+  Version : 1.0
+
+----------------------------------------------------------------------------]]--
+
+_AUTO_RELOAD_DEBUG = true
+
+--[[ manual dialog ]]-------------------------------------------------------]]--
+
+function show_manual(dialog_title, filename)
+
+  local header = table.create()
+  local pages = table.create()
+  local manual_filename = renoise.tool().bundle_path .. filename
+
+  local vb = renoise.ViewBuilder()
+  local DIALOG_MARGIN = renoise.ViewBuilder.DEFAULT_DIALOG_MARGIN
+  local CONTROL_MARGIN = renoise.ViewBuilder.DEFAULT_CONTROL_MARGIN
+
+  local row_navigation = vb:horizontal_aligner {
+    id = "navigation",
+    margin = CONTROL_MARGIN,
+    mode = "justify",
+
+    vb:valuebox {
+      id = "page_index",
+      width = "10%",
+      min = 0,
+      max = 0,
+      notifier = function(value)
+        vb.views.page_list.value = value
+      end
+    },
+    vb:popup {
+      id = "page_list",
+      width = "90%",
+      items = {},
+      notifier = function(index)
+        vb.views.page_index.value = index
+        load_page(vb.views, header, pages, index)
+      end
+    }
+  }
+
+  local row_text = vb:horizontal_aligner {
+    margin = CONTROL_MARGIN,
+
+    vb:multiline_text {
+      id = "page_text",
+      font = "mono",
+      width = 506,
+      height = 250
+    }
+  }
+
+  local dialog_content = vb:column {
+    margin = DIALOG_MARGIN,
+
+    vb:column {
+      id = "content",
+      margin = DIALOG_MARGIN,
+      style = "group",
+
+      row_navigation,
+      row_text
+    }
+  }
+
+  if io.exists(manual_filename) then
+
+    for line in io.lines(manual_filename) do
+      if not line:find("@@(.-)@@") then
+        if not pages:is_empty() then
+          pages[#pages].lines:insert(line)
+        else
+          header:insert(line)
+        end
+      else
+         pages:insert(table.create())
+         pages[#pages] = {
+           name = line:match("@@(.-)@@"),
+           lines = table.create()
+         }
+         line = line:gsub("@@", "")
+         pages[#pages].lines:insert(line)
+      end
+    end
+
+    if not pages:is_empty() then
+
+      local page_names = table.create()
+
+      for _, page in ipairs(pages) do
+        page_names:insert(page.name)
+      end
+
+      vb.views.page_list.items = page_names
+      vb.views.page_index.min = 1
+      vb.views.page_index.max = #pages
+      vb.views.page_index.value = 1
+
+    else
+      vb.views.navigation.visible = false
+    end
+
+    vb.views.content:resize()
+    load_page(vb.views, header, pages, 1)
+
+
+   renoise.app():show_custom_dialog (
+        dialog_title, dialog_content
+        )
+
+  else
+    renoise.app():show_warning (
+      "The manual could not be found, please reinstall this tool.\n\n" ..
+      "Missing file: " .. manual_filename
+    )
+  end
+
+end
+
+--[[ load page ]]-----------------------------------------------------------]]--
+
+function load_page(vbv, header, pages, page_index)
+
+  vbv.page_text.paragraphs = header
+
+  if not pages:is_empty() then
+    for _, line in ipairs(pages[page_index].lines) do
+      vbv.page_text:add_line(line)
+    end
+  end
+
+end
+
+---------------------------------------------------------------------[[ EOF ]]--

--- a/FormulaDeviceXML.txt
+++ b/FormulaDeviceXML.txt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FilterDevicePreset doc_version="9">
+  <DeviceSlot type="FormulaMetaDevice">
+    <IsMaximized>true</IsMaximized>
+    <FormulaParagraphs>
+      <FormulaParagraph/>
+    </FormulaParagraphs>
+    <FunctionsParagraphs>
+      <FunctionsParagraph/>
+    </FunctionsParagraphs>
+    <InputNameA>A</InputNameA>
+    <InputNameB>B</InputNameB>
+    <InputNameC>C</InputNameC>
+    <EditorVisible>true</EditorVisible>
+    <PanelVisible>0</PanelVisible>
+    <InputA>
+      <Value>0.0</Value>
+    </InputA>
+    <InputB>
+      <Value>0.0</Value>
+    </InputB>
+    <InputC>
+      <Value>0.0</Value>
+    </InputC>
+  </DeviceSlot>
+</FilterDevicePreset>

--- a/FormulaDeviceXML_Inertial_Slider.txt
+++ b/FormulaDeviceXML_Inertial_Slider.txt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FilterDevicePreset doc_version="9">
+  <DeviceSlot type="FormulaMetaDevice">
+    <IsMaximized>true</IsMaximized>
+    <FormulaParagraphs>
+      <FormulaParagraph>OUTPUT - (OUTPUT - A) * power_inertia(B, 0.025, 0.5)</FormulaParagraph>
+    </FormulaParagraphs>
+    <FunctionsParagraphs>
+      <FunctionsParagraph>function power_inertia(inertia, min, max)</FunctionsParagraph>
+      <FunctionsParagraph>  inertia = 1.0 - inertia</FunctionsParagraph>
+      <FunctionsParagraph>  inertia = inertia * inertia * inertia</FunctionsParagraph>
+      <FunctionsParagraph>  return min + inertia * (max - min)</FunctionsParagraph>
+      <FunctionsParagraph>end</FunctionsParagraph>
+      <FunctionsParagraph/>
+    </FunctionsParagraphs>
+    <InputNameA>Input</InputNameA>
+    <InputNameB>Inertia</InputNameB>
+    <InputNameC>_</InputNameC>
+    <EditorVisible>false</EditorVisible>
+    <PanelVisible>0</PanelVisible>
+    <InputA>
+      <Value>0.0</Value>
+    </InputA>
+    <InputB>
+      <Value>0.599999905</Value>
+    </InputB>
+    <InputC>
+      <Value>0.0</Value>
+    </InputC>
+  </DeviceSlot>
+</FilterDevicePreset>

--- a/KeyBindings_backup.xml
+++ b/KeyBindings_backup.xml
@@ -858,16 +858,6 @@
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
-          <Binding>∿ Impulse Tracker Home *2 behaviour...</Binding>
-          <Key>Option + Up</Key>
-        </KeyBinding>
-        <KeyBinding>
-          <Topic>Paketti</Topic>
-          <Binding>∿ Impulse Tracker End *2 behaviour...</Binding>
-          <Key>Option + Down</Key>
-        </KeyBinding>
-        <KeyBinding>
-          <Topic>Paketti</Topic>
           <Binding>∿ Play Current Line &amp; Advance by EditStep</Binding>
           <Key>8</Key>
         </KeyBinding>
@@ -891,8 +881,17 @@
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
+          <Binding>∿ Load Rhino 2.1 AU</Binding>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
           <Binding>∿ Load FabFilter One</Binding>
           <Key>Shift + Option + F</Key>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Load Surge</Binding>
+          <Key>Option + S</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
@@ -1091,6 +1090,14 @@
         </KeyBinding>
         <KeyBinding>
           <Topic>Track Devices</Topic>
+          <Binding>∿ Load Koen KTGranulator (AU)</Binding>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Track Devices</Topic>
+          <Binding>∿ Load Uhbik U-He Runciter</Binding>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Track Devices</Topic>
           <Binding>∿ Load SphereDelay Maybe?</Binding>
         </KeyBinding>
         <KeyBinding>
@@ -1236,6 +1243,10 @@
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
+          <Binding>∿ Whats My Song</Binding>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
           <Binding>∿ Global Edit Mode Toggle</Binding>
         </KeyBinding>
         <KeyBinding>
@@ -1269,7 +1280,6 @@
         <KeyBinding>
           <Topic>Paketti</Topic>
           <Binding>∿ 2nd Save Song</Binding>
-          <Key>Control + S</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
@@ -1365,6 +1375,14 @@
         <KeyBinding>
           <Topic>Paketti</Topic>
           <Binding>∿ Column Cycle Keyjazz 12</Binding>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Start/Stop Column Cycling</Binding>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Column Cycle Keyjazz 01_Special</Binding>
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
@@ -1926,8 +1944,35 @@
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
+          <Binding>∿ Inspect Effect Slot 2</Binding>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
           <Binding>∿ Clear Current Row</Binding>
           <Key>Shift + Command + X</Key>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Wipe Song Retain Sample</Binding>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ CapsLockChassis</Binding>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Uncollapser</Binding>
+          <Key>Option + C</Key>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Collapser</Binding>
+          <Key>Shift + Option + C</Key>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Contour Shuttle Record Prototype</Binding>
+          <Key>Option + 9</Key>
         </KeyBinding>
       </KeyBindings>
     </Category>
@@ -1965,10 +2010,12 @@
         <KeyBinding>
           <Topic>Selection</Topic>
           <Binding>Select First Entry</Binding>
+          <Key>Option + Up</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Selection</Topic>
           <Binding>Select Last Entry</Binding>
+          <Key>Option + Down</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Selection</Topic>
@@ -2874,7 +2921,6 @@
         <KeyBinding>
           <Topic>Block Operations</Topic>
           <Binding>Create Phrase from Selection</Binding>
-          <Key>Option + S</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Column Operations</Topic>
@@ -3326,8 +3372,18 @@
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
+          <Binding>∿ Impulse Tracker Home *2 behaviour...</Binding>
+          <Key>Option + Up</Key>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
           <Binding>∿ alwaysPattern</Binding>
           <Key>F10</Key>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Impulse Tracker End *2 behaviour...</Binding>
+          <Key>Option + Down</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Navigation</Topic>
@@ -3356,6 +3412,7 @@
         <KeyBinding>
           <Topic>Paketti</Topic>
           <Binding>∿ Disk Browser Focus</Binding>
+          <Key>Control + S</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
@@ -4081,6 +4138,7 @@
         <KeyBinding>
           <Topic>Paketti</Topic>
           <Binding>∿ Disk Browser Focus</Binding>
+          <Key>Control + S</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
@@ -4236,7 +4294,6 @@
         <KeyBinding>
           <Topic>Edit</Topic>
           <Binding>Copy All Devices</Binding>
-          <Key>Shift + Option + C</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Edit</Topic>
@@ -4434,6 +4491,16 @@
           <Topic>Paketti</Topic>
           <Binding>∿ To Pattern Editor</Binding>
           <Key>Shift + F5</Key>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Impulse Tracker Home *2 behaviour...</Binding>
+          <Key>Option + Up</Key>
+        </KeyBinding>
+        <KeyBinding>
+          <Topic>Paketti</Topic>
+          <Binding>∿ Impulse Tracker End *2 behaviour...</Binding>
+          <Key>Option + Down</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
@@ -5953,6 +6020,7 @@
         <KeyBinding>
           <Topic>Selection</Topic>
           <Binding>∿ Paketti 2nd Unmark Selection (CTRL-U)</Binding>
+          <Key>Command + U</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Paketti</Topic>
@@ -6420,7 +6488,6 @@
         <KeyBinding>
           <Topic>Device Chain</Topic>
           <Binding>Copy All Devices</Binding>
-          <Key>Shift + Option + C</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Device Chain</Topic>
@@ -6774,7 +6841,6 @@
         <KeyBinding>
           <Topic>Edit</Topic>
           <Binding>Copy Device Chain</Binding>
-          <Key>Shift + Option + C</Key>
         </KeyBinding>
         <KeyBinding>
           <Topic>Edit</Topic>

--- a/Leftovers.lua
+++ b/Leftovers.lua
@@ -1,0 +1,88 @@
+local lsfvariable=nil
+lsfvariable=os.tmpname("wav")
+
+local tmpvariable=nil
+local path="/Users/esaruoho/Music/samples/LogicSmartFolder/"
+local path2="SmartFolderFile" 
+
+function SampleToSF()
+local s=renoise.song()
+renoise.app():show_status("Saving")
+s.instruments[s.selected_instrument_index].samples[1].sample_buffer:save_as(lsfvariable, "wav")
+renoise.app():show_status("Saved")
+renoise.app():show_status("Moving")
+renoise.app():show_status("32Bit to 24Bit Converting")
+os.execute("sox " .. lsfvariable .. " -b 24 " .. path .. "LSF_a" .. s.selected_instrument_index .. "_opbab.wav")
+renoise.app():show_status("32Bit to 24Bit Conversion From Tmp-folder to Logic Smart Folder Done")
+os.execute("cd /Users/esaruoho/Music/samples/LogicSmartFolder;open .")
+renoise.app():show_status("Temporary File Name was " .. lsfvariable )
+end
+
+function savesamplestosmartfolder()
+local s=renoise.song()
+--local additionalname=os.clock
+for i = 1, #renoise.song().instruments do
+--instruments[i].samples[1]
+renoise.app():show_status("Saving")
+  s.instruments[i].samples[1].sample_buffer:save_as(path .. path2 .. i .. ".wav", "wav")
+os.execute("sox " .. path .. path2 .. i .. " -b 24 " .. path .. path2 .. i .. i .. ".wav")
+
+--os.execute("open -a Logic\ Pro.app /Users/esaruoho/Music/Logic/abs4/abs4/abs4.logic")
+end
+renoise.app():show_status("32Bit to 24Bit Conversion From Tmp-folder to Logic Smart Folder Done")
+os.execute("cd /Users/esaruoho/Music/samples/LogicSmartFolder;open .")
+
+end
+
+
+renoise.tool():add_keybinding {name = "Global:Paketti:Save Sample to Smart Folder", invoke = function() SampleToSF() end}
+
+renoise.tool():add_keybinding {name = "Global:Paketti:Save Samples to Smart Folder", invoke = function() savesamplestosmartfolder() end}
+----------------------------
+---------------------------------------------------------------------------------------------------------
+-- :::::Automation ExpCurve
+function drawVol()
+local pos = renoise.song().transport.edit_pos
+local pos1 = renoise.song().transport.edit_pos
+local edit = renoise.song().transport.edit_mode
+local length = renoise.song().selected_pattern.number_of_lines
+local curve = 1.105
+loadnative("Audio/Effects/Native/Gainer")
+renoise.song().selected_track.devices[2].is_maximized=false
+for i=1, length do
+renoise.song().transport.edit_mode = true
+pos.line = i
+renoise.song().transport.edit_pos = pos
+renoise.song().selected_track.devices[2].parameters[1]:record_value(math.pow(curve, i) / math.pow(curve, length))
+end
+
+renoise.song().transport.edit_mode = edit
+renoise.song().transport.edit_pos = pos1
+end
+renoise.tool():add_keybinding {name = "Global:Paketti:ExpCurveVol", invoke = function() drawVol() end}
+renoise.tool():add_menu_entry {name = "Pattern Editor:Paketti..:ExpCurveVol", invoke = function() drawVol() end}
+renoise.tool():add_menu_entry {name = "Pattern Matrix:Paketti..:ExpCurveVol", invoke = function() drawVol() end}
+--renoise.tool():add_keybinding {name = "Global:Paketti:ExpCurveVol", invoke = function() drawVol() end}
+
+
+-- Track Automation
+renoise.tool():add_menu_entry {name="Track Automation:Paketti..:ExpCurveVol", invoke = function() drawVol() end}
+renoise.tool():add_menu_entry {name="Track Automation List:Paketti..:ExpCurveVol", invoke = function() drawVol() end}
+---------------------------
+require "FormulaDeviceManual"
+
+renoise.tool():add_keybinding {name = "Global:Paketti:FormulaDevice", invoke = function()  
+renoise.app().window.lower_frame_is_visible=true
+renoise.app().window.active_lower_frame=1
+renoise.song().tracks[renoise.song().selected_track_index]:insert_device_at("Audio/Effects/Native/*Formula", 2)  
+local infile = io.open( "FormulaDeviceXML.txt", "rb" )
+local indata = infile:read( "*all" )
+renoise.song().tracks[renoise.song().selected_track_index].devices[2].active_preset_data = indata
+infile:close()
+
+show_manual (
+    "Formula Device Documentation", -- manual dialog title
+    "FormulaDevice.txt" -- the textfile which contains the manual
+  )
+end}
+

--- a/impulsetracker.lua
+++ b/impulsetracker.lua
@@ -126,10 +126,10 @@ w.active_upper_frame =1 -- Set to Disk Browser
 --w.pattern_matrix_is_visible=false
 --w.pattern_advanced_edit_is_visible=false
 --w.disk_browser_is_expanded=true
-if renoise.app().window.active_middle_frame == renoise.ApplicationWindow.MIDDLE_FRAME_INSTRUMENT_SAMPLE_MODULATION then
+if renoise.app().window.active_middle_frame == renoise.ApplicationWindow.MIDDLE_FRAME_INSTRUMENT_MIDI_EDITOR then
 renoise.app().window.active_middle_frame = renoise.ApplicationWindow.MIDDLE_FRAME_INSTRUMENT_PLUGIN_EDITOR
 else
-renoise.app().window.active_middle_frame = renoise.ApplicationWindow.MIDDLE_FRAME_INSTRUMENT_SAMPLE_MODULATION end
+renoise.app().window.active_middle_frame = renoise.ApplicationWindow.MIDDLE_FRAME_INSTRUMENT_MIDI_EDITOR end
 --if renoise.app().window.active_middle_frame==renoise.Instrument.TAB_PLUGIN then renoise.app().window.active_middle_frame=5 else
 --renoise.app().window.active_middle_frame=renoise.Instrument.TAB_PLUGIN end
 end
@@ -694,10 +694,13 @@ return end
   s.selected_note_column_index=1
 end
 
-renoise.tool():add_keybinding {name="Global:Paketti:Impulse Tracker Home *2 behaviour...", invoke=function() alwaysPattern()
+renoise.tool():add_keybinding {name="Pattern Editor:Paketti:Impulse Tracker Home *2 behaviour...", invoke=function() alwaysPattern()
 homehome() 
 end }
 
+renoise.tool():add_keybinding {name="Mixer:Paketti:Impulse Tracker Home *2 behaviour...", invoke=function() alwaysPattern()
+homehome() 
+end }
 
 renoise.tool():add_keybinding {name="Pattern Editor:Paketti:alwaysPattern", invoke=function() alwaysPattern()
 end }
@@ -792,9 +795,12 @@ end
   
 end
 
-renoise.tool():add_keybinding {name="Global:Paketti:Impulse Tracker End *2 behaviour...", invoke=function() alwaysPattern() 
-endend()
-end }
+renoise.tool():add_keybinding {name="Pattern Editor:Paketti:Impulse Tracker End *2 behaviour...", invoke=function() alwaysPattern() 
+endend() end }
+
+renoise.tool():add_keybinding {name="Mixer:Paketti:Impulse Tracker End *2 behaviour...", invoke=function() alwaysPattern() 
+endend() end }
+
 
 function alwaysPattern()
 renoise.app().window.active_middle_frame=1

--- a/loaders.lua
+++ b/loaders.lua
@@ -54,43 +54,70 @@ function instrument_is_empty(instrument)
 end
 
 function search_empty_instrument()
-        local proc = renoise.song()
-        for empty_instrument = 1, #proc.instruments do
-                local samples = false
-
-                for i = 1,#proc.instruments[empty_instrument].samples do
-                        local temp_buffer = proc.instruments[empty_instrument].samples[i].sample_buffer
-                        if temp_buffer.has_sample_data then
-                                samples = true
-                                break
-                        end
-                end
-                local plugin = proc.instruments[empty_instrument].plugin_properties.plugin_loaded
-                local midi_device = proc.instruments[empty_instrument].midi_output_properties.device_name
-                if ((samples == false) and (plugin == false) and 
-                        (midi_device == nil or midi_device == "")) then
-                        return empty_instrument
-                end
-        end
-        proc:insert_instrument_at(#proc.instruments+1)
-        return #proc.instruments
+  local proc = renoise.song()
+  for empty_instrument = 1, #proc.instruments do
+    local samples = false
+                
+      for i = 1,#proc.instruments[empty_instrument].samples do
+        local temp_buffer = proc.instruments[empty_instrument].samples[i].sample_buffer
+          if temp_buffer.has_sample_data then samples = true break
+          end
+      end
+  local plugin = proc.instruments[empty_instrument].plugin_properties.plugin_loaded
+  local midi_device = proc.instruments[empty_instrument].midi_output_properties.device_name
+    if ((samples == false) and (plugin == false) and 
+        (midi_device == nil or midi_device == "")) then
+    return empty_instrument
+    end
+    end
+   proc:insert_instrument_at(#proc.instruments+1)
+  return #proc.instruments
 end
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
-function LoadZebra()
+------------------------------------------------------------------------------------------------------------
+function LoadRhino()
 local s=renoise.song()
 s.selected_instrument_index = search_empty_instrument()
-renoise.song().selected_instrument.plugin_properties:load_plugin("Audio/Generators/VST/Zebra2")
+renoise.song().selected_instrument.plugin_properties:load_plugin("Audio/Generators/AU/aumu:RNB4:VSTA")
 if renoise.song().selected_instrument.plugin_properties.plugin_loaded
  then
  local pd=renoise.song().selected_instrument.plugin_properties.plugin_device
  if pd.external_editor_visible==false then pd.external_editor_visible=true else pd.external_editor_visible=false end
  end
+renoise.app().window.active_lower_frame=3
+renoise.song().selected_instrument.active_tab=2 
+end
+
+renoise.tool():add_keybinding  {name="Global:Paketti:Load Rhino 2.1 AU", invoke = function() LoadRhino() end}
+------------------------------------------------------------------------------------------------------------
+renoise.tool():add_keybinding {name = "Global:Paketti:Load FabFilter One", invoke = function()  renoise.song().instruments[renoise.song().selected_instrument_index].plugin_properties:load_plugin("Audio/Generators/AU/aumu:FOne:FabF")
+local pd=renoise.song().selected_instrument.plugin_properties.plugin_device
+ if pd.external_editor_visible==false then pd.external_editor_visible=true end end}
+------------------------------------------------------------------------------------------------------------
+renoise.tool():add_keybinding {name = "Global:Paketti:Load Surge", invoke = function()  renoise.song().instruments[renoise.song().selected_instrument_index].plugin_properties:load_plugin("Audio/Generators/VST/Surge")
+local pd=renoise.song().selected_instrument.plugin_properties.plugin_device
+ if pd.external_editor_visible==false then pd.external_editor_visible=true end 
+ 
+
+renoise.app().window.active_middle_frame=renoise.ApplicationWindow.MIDDLE_FRAME_PATTERN_EDITOR
+renoise.app().window.lock_keyboard_focus=true
+
+
+ end}
+------------------------------------------------------------------------------------------------------------
+function LoadZebra()
+local s=renoise.song()
+s.selected_instrument_index = search_empty_instrument()
+renoise.song().selected_instrument.plugin_properties:load_plugin("Audio/Generators/VST/Zebra2")
+if renoise.song().selected_instrument.plugin_properties.plugin_loaded then
+ local pd=renoise.song().selected_instrument.plugin_properties.plugin_device
+ if pd.external_editor_visible==false then pd.external_editor_visible=true else pd.external_editor_visible=false end
+end
 --renoise.app().window.active_lower_frame=3
 renoise.app().window.active_middle_frame=3
 renoise.song().selected_instrument.active_tab=2 
 end
 renoise.tool():add_keybinding {name="Global:Paketti:Load U-He Zebra", invoke=function() LoadZebra() end}
-------------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------
 function LoadPPG()
 local s=renoise.song()
 s.selected_instrument_index = search_empty_instrument()
@@ -109,7 +136,7 @@ renoise.song().selected_instrument.active_tab=2
 
 end
 renoise.tool():add_keybinding {name="Global:Paketti:Load Waldorf PPG v2", invoke=function() LoadPPG() end}
-------------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------
 function LoadAttack()
 local s=renoise.song()
 s.selected_instrument_index = search_empty_instrument()
@@ -123,7 +150,7 @@ renoise.app().window.active_middle_frame=3
 renoise.song().selected_instrument.active_tab=2 
 end
 renoise.tool():add_keybinding  {name="Global:Paketti:Load Waldorf Attack", invoke=function() LoadAttack() end}
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------
 function loadnative(effect)
 local checkline=nil
    if (table.count(renoise.song().selected_track.devices)) <2 then checkline=2
@@ -269,12 +296,13 @@ else renoise.app().window.lower_frame_is_visible=true end
 
 -- renoise.app().window.active_lower_frame=1
  renoise.song().selected_track:insert_device_at(vstname, checkline)
- renoise.song().selected_track.devices[checkline].external_editor_visible=true
- renoise.song().selected_track.devices[checkline].is_maximized=false
+   if renoise.song().selected_track.devices[checkline].name=="AU: Koen Tanghe @ Smartelectronix: KTGranulator" then return
+   else renoise.song().selected_track.devices[checkline].external_editor_visible=true end
+  renoise.song().selected_track.devices[checkline].is_maximized=false
 -- renoise.song().selected_track.devices[checkline].plugin_properties.auto_suspend=false
 -- the one above is just for plugins :( not available for actual track devices
  
- renoise.song().selected_device_index= checkline
+ renoise.song().selected_device_index=checkline
  
   if renoise.song().selected_track.devices[checkline].name=="VST: Schaack Audio Technologies: TransientShaper" then 
   renoise.song().selected_track.devices[checkline].parameters[1].show_in_mixer=true
@@ -303,6 +331,18 @@ else renoise.app().window.lower_frame_is_visible=true end
      renoise.song().selected_track.devices[checkline].parameters[1].value=0.474 -- Mix 
      renoise.song().selected_track.devices[checkline].parameters[3].value=0.688 -- Decay 
   else end 
+
+  if renoise.song().selected_track.devices[checkline].name=="AU: Koen Tanghe @ Smartelectronix: KTGranulator" then 
+     renoise.app().window.lower_frame_is_visible=true
+     renoise.app().window.active_lower_frame=1
+     renoise.song().selected_track.devices[checkline].is_maximized=true
+     renoise.song().selected_track.devices[checkline].parameters[31].value=1 --SplitPitch
+     renoise.song().selected_track.devices[checkline].parameters[16].value=0.75 --maxTransp
+     renoise.song().selected_track.devices[checkline].parameters[2].value=0.50 --Mix
+     renoise.song().selected_track.devices[checkline].parameters[3].value=0.35 --Mix
+     renoise.song().selected_track.devices[checkline].parameters[6].value=0.75 --Mix
+  else end 
+ 
 end
 
 --Audio/Effects/AU/aufx:cHL1:TOGU
@@ -310,6 +350,14 @@ end
 --73  Audio/Effects/AU/aumf:676v:TOGU
 --- AU
 -- Audio/Effects/AU/aufx:sdly:appl
+
+renoise.tool():add_keybinding {name="Global:Track Devices:Load Koen KTGranulator (AU)",
+invoke = function() 
+loadvst("Audio/Effects/AU/aufx:KTGr:KTfx") end}
+
+
+renoise.tool():add_keybinding {name="Global:Track Devices:Load Uhbik U-He Runciter", invoke = function() loadvst("Audio/Effects/AU/aumf:Rc17:UHfX") end}
+
 renoise.tool():add_keybinding {name="Global:Track Devices:Load SphereDelay Maybe?", invoke=function() loadvst("Audio/Effects/AU/aufx:SpDl:No1z") end}
 renoise.tool():add_keybinding {name="Global:Track Devices:Load D16 Syntorus", invoke=function() loadvst("Audio/Effects/AU/aufx:Sn7R:d16g") end}
 renoise.tool():add_keybinding {name="Global:Track Devices:Load D16 Toraverb", invoke=function() loadvst("Audio/Effects/AU/aufx:T4V8:d16g") end}


### PR DESCRIPTION
- Add FabFilter One (AU) to shortcuts (Alt-Shift-F)
- Further Patchetti culling
- Bring back "Clear Current Row" shortcut from Patchetti to Paketti
- "What's My Song" shortcut moved from Patchetti to Paketti, mapped to Shift-Alt-W
- CapsLockChassis (32 rows of length) brought from Patchetti to Paketti
- Add KTGranulator (AU) to shortcuts (Shift-K) with configuration
- Add Runciter (AU) to shortcuts (Shift-K)
- Add Inspect shortcut for showing 2nd slot effect (CTRL-A)
- Move Collapser / Uncollapser from Patchetti to Paketti. (Shift-Alt-C / Alt-C)
- Build prototype for sampling with ContourShuttle V2
- Tweak F4 to switch between Plugin + Midi tab
- Disk Browser focus work
- Modifying Home / End to be in Mixer and in Pattern Editor